### PR TITLE
Changing Audience to interface{}. Now it's possible to pass a []strin…

### DIFF
--- a/type.go
+++ b/type.go
@@ -22,7 +22,7 @@ type Claims struct {
 	Subject string `json:"sub,omitempty"`
 
 	// Audience ("aud") identifies the recipients that the JWT is intended for.
-	Audience string `json:"aud,omitempty"`
+	Audience interface{} `json:"aud,omitempty"`
 
 	// Expiration ("exp") identifies the expiration time on or after which the
 	// JWT MUST NOT be accepted for processing.


### PR DESCRIPTION
As the RFC: https://tools.ietf.org/html/rfc7519#section-4.1.3: 
" In the general case, the "aud" value is an array of case-
   sensitive strings, each containing a StringOrURI value.  In the
   special case when the JWT has one audience, the "aud" value MAY be a
   single case-sensitive string containing a StringOrURI value.  The
   interpretation of audience values is generally application specific.
   Use of this claim is OPTIONAL."
To keep backward compatibility, I changed the type to interface{} instead of []string. Then the caller can choose what type he will use, string or []string.